### PR TITLE
ci(dist): use HOMEBREW_TAP_TOKEN as GH_TOKEN for tap publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,10 +264,11 @@ jobs:
           persist-credentials: false
           submodules: recursive
       # Expose HOMEBREW_TAP_TOKEN to dist directly; it reads this by name
-      - name: Export HOMEBREW_TAP_TOKEN for dist
+      - name: Use HOMEBREW_TAP_TOKEN for GitHub API (tap PRs)
         if: ${{ env.HOMEBREW_TAP_TOKEN != '' }}
         run: |
-          echo "HOMEBREW_TAP_TOKEN=${HOMEBREW_TAP_TOKEN}" >> $GITHUB_ENV
+          echo "GH_TOKEN=${HOMEBREW_TAP_TOKEN}" >> $GITHUB_ENV
+          echo "GITHUB_TOKEN=${HOMEBREW_TAP_TOKEN}" >> $GITHUB_ENV
       - name: Install cached dist
         uses: actions/download-artifact@v4
         with:
@@ -334,10 +335,11 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - name: Export HOMEBREW_TAP_TOKEN for dist
+      - name: Use HOMEBREW_TAP_TOKEN for GitHub API (tap PRs)
         if: ${{ env.HOMEBREW_TAP_TOKEN != '' }}
         run: |
-          echo "HOMEBREW_TAP_TOKEN=${HOMEBREW_TAP_TOKEN}" >> $GITHUB_ENV
+          echo "GH_TOKEN=${HOMEBREW_TAP_TOKEN}" >> $GITHUB_ENV
+          echo "GITHUB_TOKEN=${HOMEBREW_TAP_TOKEN}" >> $GITHUB_ENV
       - name: Install cached dist
         uses: actions/download-artifact@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "fdbdir"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "clap",
@@ -564,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
  "bitflags",
  "libc",
@@ -869,9 +869,9 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "serde"
-version = "1.0.221"
+version = "1.0.223"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "341877e04a22458705eb4e131a1508483c877dca2792b3781d4e5d8a6019ec43"
+checksum = "a505d71960adde88e293da5cb5eda57093379f64e61cf77bf0e6a63af07a7bac"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -879,27 +879,28 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.17"
+version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
+checksum = "fe07b5d88710e3b807c16a06ccbc9dfecd5fff6a4d2745c59e3e26774f10de6a"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "serde_core"
-version = "1.0.221"
+version = "1.0.223"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c459bc0a14c840cb403fc14b148620de1e0778c96ecd6e0c8c3cacb6d8d00fe"
+checksum = "20f57cbd357666aa7b3ac84a90b4ea328f1d4ddb6772b430caa5d9e1309bb9e9"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.221"
+version = "1.0.223"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6185cf75117e20e62b1ff867b9518577271e58abe0037c40bb4794969355ab0"
+checksum = "3d428d07faf17e306e699ec1e91996e5a165ba5d6bce5b5155173e91a8a01a56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -908,13 +909,14 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56177480b00303e689183f110b4e727bb4211d692c62d4fcd16d02be93077d40"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
  "serde_core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdbdir"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2021"
 description = "FoundationDB Directory Explorer CLI (interactive REPL with tuple decoding)"
 repository = "https://github.com/panghy/fdbdir"


### PR DESCRIPTION
Ensure cargo-dist has write access to panghy/homebrew-tap by overriding GH_TOKEN/GITHUB_TOKEN with HOMEBREW_TAP_TOKEN in host and announce jobs.