### PR TITLE
release: v0.1.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "fdbdir"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdbdir"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2021"
 description = "FoundationDB Directory Explorer CLI (interactive REPL with tuple decoding)"
 repository = "https://github.com/panghy/fdbdir"


### PR DESCRIPTION
Bump version to v0.1.19 to trigger Release workflow with merged HOMEBREW_TAP_TOKEN wiring. After merge, we will create the v0.1.19 tag/release to publish artifacts and open the Homebrew tap PR automatically.