### PR TITLE
ci: refresh Cargo.lock during release bump

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -24,8 +24,16 @@ awk -v ver="$VERSION_INPUT" '
   { print }
 ' Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
 
-# Commit and tag
-git add Cargo.toml
+# Regenerate lockfile to reflect the new local package version without changing deps
+if command -v cargo >/dev/null 2>&1; then
+  # Prefer offline to avoid network; fall back to online if needed
+  if ! cargo generate-lockfile --offline >/dev/null 2>&1; then
+    cargo generate-lockfile >/dev/null 2>&1 || true
+  fi
+fi
+
+# Commit and tag (include Cargo.lock so CI with --locked won't fail)
+git add Cargo.toml Cargo.lock
 git commit -m "release ${TAG}"
 git tag "${TAG}"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -32,11 +32,11 @@ if command -v cargo >/dev/null 2>&1; then
       echo "Error: Failed to generate Cargo.lock file online." >&2
       exit 1
     fi
-    # Verify Cargo.lock exists and is non-empty
-    if [[ ! -s Cargo.lock ]]; then
-      echo "Error: Cargo.lock was not generated or is empty." >&2
-      exit 1
-    fi
+  fi
+  # Verify Cargo.lock exists and is non-empty
+  if [[ ! -s Cargo.lock ]]; then
+    echo "Error: Cargo.lock was not generated or is empty." >&2
+    exit 1
   fi
 fi
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -25,19 +25,21 @@ awk -v ver="$VERSION_INPUT" '
 ' Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
 
 # Regenerate lockfile to reflect the new local package version without changing deps
-if command -v cargo >/dev/null 2>&1; then
-  # Prefer offline to avoid network; fall back to online if needed
-  if ! cargo generate-lockfile --offline >/dev/null 2>&1; then
-    if ! cargo generate-lockfile >/dev/null 2>&1; then
-      echo "Error: Failed to generate Cargo.lock file (tried both offline and online modes)." >&2
-      exit 1
-    fi
-  fi
-  # Verify Cargo.lock exists and is non-empty
-  if [[ ! -s Cargo.lock ]]; then
-    echo "Error: Cargo.lock was not generated or is empty." >&2
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "Error: 'cargo' command not found. This script requires cargo to release Rust projects." >&2
+  exit 1
+fi
+# Prefer offline to avoid network; fall back to online if needed
+if ! cargo generate-lockfile --offline >/dev/null 2>&1; then
+  if ! cargo generate-lockfile >/dev/null 2>&1; then
+    echo "Error: Failed to generate Cargo.lock file (tried both offline and online modes)." >&2
     exit 1
   fi
+fi
+# Verify Cargo.lock exists and is non-empty
+if [[ ! -s Cargo.lock ]]; then
+  echo "Error: Cargo.lock was not generated or is empty." >&2
+  exit 1
 fi
 
 # Commit and tag (include Cargo.lock so CI with --locked won't fail)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -41,7 +41,11 @@ if command -v cargo >/dev/null 2>&1; then
 fi
 
 # Commit and tag (include Cargo.lock so CI with --locked won't fail)
-git add Cargo.toml Cargo.lock
+if [ -f Cargo.lock ]; then
+  git add Cargo.toml Cargo.lock
+else
+  git add Cargo.toml
+fi
 git commit -m "release ${TAG}"
 git tag "${TAG}"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -29,7 +29,7 @@ if command -v cargo >/dev/null 2>&1; then
   # Prefer offline to avoid network; fall back to online if needed
   if ! cargo generate-lockfile --offline >/dev/null 2>&1; then
     if ! cargo generate-lockfile >/dev/null 2>&1; then
-      echo "Error: Failed to generate Cargo.lock file online." >&2
+      echo "Error: Failed to generate Cargo.lock file (tried both offline and online modes)." >&2
       exit 1
     fi
   fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -28,7 +28,15 @@ awk -v ver="$VERSION_INPUT" '
 if command -v cargo >/dev/null 2>&1; then
   # Prefer offline to avoid network; fall back to online if needed
   if ! cargo generate-lockfile --offline >/dev/null 2>&1; then
-    cargo generate-lockfile >/dev/null 2>&1 || true
+    if ! cargo generate-lockfile >/dev/null 2>&1; then
+      echo "Error: Failed to generate Cargo.lock file online." >&2
+      exit 1
+    fi
+    # Verify Cargo.lock exists and is non-empty
+    if [[ ! -s Cargo.lock ]]; then
+      echo "Error: Cargo.lock was not generated or is empty." >&2
+      exit 1
+    fi
   fi
 fi
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -43,11 +43,7 @@ if [[ ! -s Cargo.lock ]]; then
 fi
 
 # Commit and tag (include Cargo.lock so CI with --locked won't fail)
-if [ -f Cargo.lock ]; then
-  git add Cargo.toml Cargo.lock
-else
-  git add Cargo.toml
-fi
+git add Cargo.toml Cargo.lock
 git commit -m "release ${TAG}"
 git tag "${TAG}"
 


### PR DESCRIPTION
Ensure scripts/release.sh runs 'cargo generate-lockfile' and commits Cargo.lock to avoid CI --locked failures.