### PR TITLE
ci: harden Homebrew assert

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -367,13 +367,13 @@ jobs:
           TAP_REPO: panghy/homebrew-tap
         run: |
           set -euo pipefail
-          if rg -n "publish-jobs\s*=.*homebrew" dist-workspace.toml >/dev/null; then
+          if grep -E -q 'publish-jobs\s*=.*homebrew' dist-workspace.toml; then
             echo "Homebrew publishing enabled; verifying PR exists in ${TAP_REPO}..."
             # Look for an open PR mentioning this repo/package in title
             PR_URL=$(gh pr list -R "$TAP_REPO" --state open --search "fdbdir in:title" --json url -q '.[0].url' || true)
             if [ -z "${PR_URL}" ]; then
               echo "::error::No open Homebrew PR found in ${TAP_REPO}. cargo-dist announce likely failed silently." >&2
-              echo "Hint: Ensure HOMEBREW_TAP_TOKEN has repo scope and access to ${TAP_REPO}." >&2
+              echo "Hint: Ensure HOMEBREW_TAP_TOKEN has repo scope AND Contents: write on ${TAP_REPO}." >&2
               echo "Also check dist-announce.json artifact for detailed logs." >&2
               exit 1
             else


### PR DESCRIPTION
- Use grep instead of rg on runners\n- Clarify HOMEBREW_TAP_TOKEN needs Contents: write on panghy/homebrew-tap\n- Fail loudly if no PR exists