### PR TITLE
ci: remove invalid dist host --steps=publish; rely on announce for Homebrew PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,7 +285,9 @@ jobs:
       - id: host
         shell: bash
         run: |
-          dist host ${{ needs.plan.outputs.tag-flag }} --steps=upload --steps=release --steps=publish --output-format=json > dist-manifest.json
+          # Note: cargo-dist's 'host' does not support a separate 'publish' step.
+          # Homebrew tap PRs are handled during 'announce' (and we have a fallback below).
+          dist host ${{ needs.plan.outputs.tag-flag }} --steps=upload --steps=release --output-format=json > dist-manifest.json
           echo "artifacts uploaded and released successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Context: cargo-dist host does not support a 'publish' step (valid: check, create, upload, release, announce). The previous change caused host to fail before announce could run and before the Homebrew fallback could trigger.

This removes --steps=publish from the host job. Homebrew PRs will be handled during announce (and we keep the gh fallback).

After merge: tag v0.1.30 and verify that announce opens the tap PR (or the fallback does).