### PR TITLE
release v0.1.30

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,7 +285,9 @@ jobs:
       - id: host
         shell: bash
         run: |
-          dist host ${{ needs.plan.outputs.tag-flag }} --steps=upload --steps=release --steps=publish --output-format=json > dist-manifest.json
+          # Note: cargo-dist's 'host' does not support a separate 'publish' step.
+          # Homebrew tap PRs are handled during 'announce' (and we have a fallback below).
+          dist host ${{ needs.plan.outputs.tag-flag }} --steps=upload --steps=release --output-format=json > dist-manifest.json
           echo "artifacts uploaded and released successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "fdbdir"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdbdir"
-version = "0.1.29"
+version = "0.1.30"
 edition = "2021"
 description = "FoundationDB Directory Explorer CLI (interactive REPL with tuple decoding)"
 repository = "https://github.com/panghy/fdbdir"


### PR DESCRIPTION
Cut 0.1.30 to pick up fixed Release workflow (no invalid --steps=publish). After merge, tag v0.1.30 and verify Homebrew tap PR is opened during announce (or via fallback).