### PR TITLE
release v0.1.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "fdbdir"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdbdir"
-version = "0.1.31"
+version = "0.1.32"
 edition = "2021"
 description = "FoundationDB Directory Explorer CLI (interactive REPL with tuple decoding)"
 repository = "https://github.com/panghy/fdbdir"


### PR DESCRIPTION
Cut 0.1.32 to include rpath support for FoundationDB client.